### PR TITLE
feat(remote): add support for re-creating resource when removed on remote

### DIFF
--- a/internal/provider/custom_resource.go
+++ b/internal/provider/custom_resource.go
@@ -351,6 +351,12 @@ func (r *customCrudResource) Read(ctx context.Context, req resource.ReadRequest,
 	result, err := r.executeScript(ctx, readCmd, payload)
 	if err != nil {
 		payloadJSON, _ := json.Marshal(payload)
+		// Treat exit code 22 from script as a signal to recreate resource
+    	// and return early
+		if result.ExitCode == 22 {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Read Script Failed", fmt.Sprintf("%v\nExit Code: %d\nStdout: %s\nStderr: %s\nInput Payload: %s", err, result.ExitCode, result.Stdout, result.Stderr, string(payloadJSON)))
 		return
 	}

--- a/internal/provider/test_resource_removed_remote/read_simulate_removed_remote.sh
+++ b/internal/provider/test_resource_removed_remote/read_simulate_removed_remote.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+exit 22


### PR DESCRIPTION


## Description

Add logic so that if a read script returns 22, it will force recreation of the resource in the next TF Plan / Apply

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [X] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
