### PR TITLE
feat(id): make id immutable, update makefile to cross platform

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,10 +1,11 @@
 default: fmt lint install generate
 
+local_registry_path=$(HOME)/.terraform.d/plugins/registry.terraform.io/customcrud/customcrud/1.0.0/$(shell go env GOOS)_$(shell go env GOARCH)
 build:
 	go build -o terraform-provider-customcrud
-	cp terraform-provider-customcrud ~/.terraform.d/plugins/registry.terraform.io/customcrud/customcrud/1.0.0/linux_amd64/
-	rm -f examples/.terraform.lock.hcl
-	cd examples && terraform init
+	mkdir -p "$(local_registry_path)"
+	cp terraform-provider-customcrud "$(local_registry_path)/terraform-provider-customcrud"
+	cd examples/file && rm -f .terraform.lock.hcl && terraform init
 
 install: build
 	go install -v ./...

--- a/internal/provider/custom_resource.go
+++ b/internal/provider/custom_resource.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -59,6 +61,9 @@ func (r *customCrudResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Resource identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"input": schema.DynamicAttribute{
 				Optional:    true,


### PR DESCRIPTION
- Makes `id` field immutable once set, this reduces noise in plans where there are resources dependent upon `id` (see example)
- Update makefile to use `go env` for mac/linux compatibility

### `id` immutability example
```terraform
  # customcrud.file will be updated in-place
  ~ resource "customcrud" "file" {
      ~ id     = "/var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.gXnrXkktmC" -> (known after apply)
      ~ input  = {
          ~ content = "Hello, Wdorld!" -> "Hello, World!"
        }
      ~ output = {
          - content = "Hello, Wdorld!"
          - id      = "/var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.gXnrXkktmC"
        } -> (known after apply)

        # (1 unchanged block hidden)
    }

  # customcrud.file2 will be updated in-place
  ~ resource "customcrud" "file2" {
      ~ id     = "/var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.mV3oRLC4EG" -> (known after apply)
      ~ input  = {
          ~ content = "Hello, World! /var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.gXnrXkktmC" -> (known after apply)
        }
      ~ output = {
          - content = "Hello, World! /var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.gXnrXkktmC"
          - id      = "/var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.mV3oRLC4EG"
        } -> (known after apply)

        # (1 unchanged block hidden)
    }
```

now becomes:

```terraform
  # customcrud.file will be updated in-place
  ~ resource "customcrud" "file" {
        id     = "/var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.gXnrXkktmC"
      ~ input  = {
          ~ content = "Hello, Wdorld!" -> "Hello, World!"
        }
      ~ output = {
          - content = "Hello, Wdorld!"
          - id      = "/var/folders/f3/fcyq6jtj61jch8q7zt8khw2r0000gn/T/tmp.gXnrXkktmC"
        } -> (known after apply)

        # (1 unchanged block hidden)
    }
```