### PR TITLE
fix(dynamic): fix dynamic casting in case where list is empty

### DIFF
--- a/internal/provider/custom_resource_test.go
+++ b/internal/provider/custom_resource_test.go
@@ -85,6 +85,12 @@ func TestAccExampleResourceEdgeCases(t *testing.T) {
 					resource.TestCheckResourceAttr("customcrud.test", "output.a.5.0", "1"),
 					resource.TestCheckResourceAttr("customcrud.test", "output.a.5.1", "2"),
 					resource.TestCheckResourceAttr("customcrud.test", "output.a.5.2", "3"),
+
+					resource.TestCheckResourceAttr("customcrud.test", "output.b.c.#", "3"),
+					resource.TestCheckResourceAttr("customcrud.test", "output.b.c.0", "a"),
+					resource.TestCheckResourceAttr("customcrud.test", "output.b.c.1", "b"),
+					resource.TestCheckResourceAttr("customcrud.test", "output.b.c.2", "c"),
+					resource.TestCheckResourceAttr("customcrud.test", "output.b.d.#", "0"),
 				),
 				// jq -n '{id: 1, a: [1, "2", false, null, [{"b": 3}], [1, 2, 3]]}'
 			},
@@ -93,7 +99,7 @@ func TestAccExampleResourceEdgeCases(t *testing.T) {
 				Config:                  testAccExampleResourceEdgeCaseConfig(createScript, readScript, deleteScript),
 				ResourceName:            "customcrud.test",
 				ImportState:             true,
-				ImportStateIdFunc:       testAccResourceImportStateIdFunc("customcrud.test", "{\"input\":{\"b\":{\"c\":[\"a\",\"b\",\"c\"]}}}", createScript, readScript, "", deleteScript),
+				ImportStateIdFunc:       testAccResourceImportStateIdFunc("customcrud.test", "{\"input\":{\"b\":{\"c\":[\"a\",\"b\",\"c\"],\"d\":[]}}}", createScript, readScript, "", deleteScript),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"hooks"},
 			},
@@ -403,6 +409,7 @@ resource "customcrud" "test" {
   input = {
     b = {
       c = ["a", "b", "c"]
+	  d = []
     }
   }
 }

--- a/internal/provider/test_edgecases/create.sh
+++ b/internal/provider/test_edgecases/create.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-jq -n '{id: 1, a: [1, "2", false, null, [{"b": 3}], [1, 2, 3]], b: {c: ["a","b","c"]}}'
+jq -n '{id: 1, a: [1, "2", false, null, [{"b": 3}], [1, 2, 3]], b: {c: ["a","b","c"], d: []}}'

--- a/internal/provider/test_edgecases/main.tf
+++ b/internal/provider/test_edgecases/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    customcrud = {
+      source = "registry.terraform.io/customcrud/customcrud"
+    }
+  }
+}
+
+provider "customcrud" {}
+
+resource "customcrud" "test" {
+  hooks {
+    create = "./create.sh"
+    read   = "./read.sh"
+    delete = "./delete.sh"
+  }
+
+  input = {
+    b = {
+      c = ["a", "b", "c"]
+      d = []
+    }
+  }
+}

--- a/internal/provider/test_edgecases/read.sh
+++ b/internal/provider/test_edgecases/read.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-jq -n '{id: 1, a: [1, "2", false, null, [{"b": 3}], [1, 2, 3]], b: {c: ["a","b","c"]}}'
+jq -n '{id: 1, a: [1, "2", false, null, [{"b": 3}], [1, 2, 3]], b: {c: ["a","b","c"], d: []}}'

--- a/internal/provider/utils/dynamic.go
+++ b/internal/provider/utils/dynamic.go
@@ -27,10 +27,6 @@ func InterfaceToAttrValue(data interface{}) attr.Value {
 	case bool:
 		return types.BoolValue(v)
 	case []interface{}:
-		if len(v) == 0 {
-			listVal, _ := types.ListValue(types.DynamicType, []attr.Value{})
-			return listVal
-		}
 		elements := make([]attr.Value, len(v))
 		for i, elem := range v {
 			elements[i] = InterfaceToAttrValue(elem)


### PR DESCRIPTION
- fix(dynamic): fix dynamic casting in case where list is empty

This was accidentally left behind after the recent list/tuple rework. This has been added to the test suite to prevent future breakages!