### PR TITLE
feat(provider): add config option for high precision numbers when parsing outputs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,4 +33,5 @@ provider "customcrud" {
 
 ### Optional
 
+- `high_precision_numbers` (Boolean) Enable high precision for floating point numbers. This will cause the json parsing for outputs to use 512-bit floats instead of the default 64-bit.
 - `parallelism` (Number) Maximum number of scripts to execute in parallel. 0 means unlimited (default).

--- a/examples/file/hooks/delete.sh
+++ b/examples/file/hooks/delete.sh
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
 set -e
-
-input="$(cat)"
-id="$(echo "$input" | jq -r '.id')"
-rm "$id"

--- a/internal/provider/test_precision/create.sh
+++ b/internal/provider/test_precision/create.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+input="$(cat)"
+target="$(echo "$input" | jq -r .input.target)"
+
+jq -n --arg target $target '{target: $target | tonumber, id: "1"}'

--- a/internal/provider/test_precision/delete.sh
+++ b/internal/provider/test_precision/delete.sh
@@ -1,0 +1,1 @@
+../../../examples/file/hooks/delete.sh

--- a/internal/provider/test_precision/read.sh
+++ b/internal/provider/test_precision/read.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+input="$(cat)"
+target="$(echo "$input" | jq -r .output.target)"
+
+jq -n --arg target $target '{target: $target | tonumber, id: "1"}'

--- a/internal/provider/test_precision/update.sh
+++ b/internal/provider/test_precision/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+input="$(cat)"
+target="$(echo "$input" | jq -r .input.target)"
+
+jq -n --arg target $target '{target: $target | tonumber, id: "1"}'

--- a/internal/provider/utils/exec.go
+++ b/internal/provider/utils/exec.go
@@ -25,7 +25,7 @@ type ExecutionResult struct {
 }
 
 // Execute runs the given command with the provided payload, returning the result and any error.
-func Execute(ctx context.Context, cmd []string, payload ExecutionPayload) (*ExecutionResult, error) {
+func Execute(ctx context.Context, config CustomCRUDProviderConfig, cmd []string, payload ExecutionPayload) (*ExecutionResult, error) {
 	if len(cmd) == 0 {
 		return nil, fmt.Errorf("empty command")
 	}
@@ -83,7 +83,11 @@ func Execute(ctx context.Context, cmd []string, payload ExecutionPayload) (*Exec
 	}
 
 	var jsonResult map[string]interface{}
-	if err := json.Unmarshal(stdout.Bytes(), &jsonResult); err != nil {
+	d := json.NewDecoder(&stdout)
+	if config.HighPrecisionNumbers {
+		d.UseNumber()
+	}
+	if err := d.Decode(&jsonResult); err != nil {
 		return result, fmt.Errorf("failed to parse script output: %w", err)
 	}
 


### PR DESCRIPTION
## Related Issue

Fixes #42 

## Description

Adds support for `high_precision_numbers` flag at provider level. This will cause the json parsing for outputs to use 512-bit floats instead of the default 64-bit. Refactored the provider config to better support new options in future.