### PR TITLE
fix(exec): split command arguments taking quotes into consideration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,4 +63,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	mvdan.cc/sh/v3 v3.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -242,3 +242,5 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+mvdan.cc/sh/v3 v3.12.0 h1:ejKUR7ONP5bb+UGHGEG/k9V5+pRVIyD+LsZz7o8KHrI=
+mvdan.cc/sh/v3 v3.12.0/go.mod h1:Se6Cj17eYSn+sNooLZiEUnNNmNxg0imoYlTu4CyaGyg=

--- a/internal/provider/custom_resource_test.go
+++ b/internal/provider/custom_resource_test.go
@@ -587,6 +587,38 @@ resource "customcrud" "test_float" {
 	})
 }
 
+func TestAccResourceHooksWhitespaceArgs(t *testing.T) {
+	createScript := `test_whitespace_args/create.sh --label="hello world"`
+	readScript := `test_whitespace_args/read.sh --label="hello world"`
+	deleteScript := "test_whitespace_args/delete.sh"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "customcrud" "test_ws" {
+  hooks {
+    create = %q
+    read   = %q
+    delete = %q
+  }
+  input = {
+    name = "whitespace-test"
+  }
+}
+`, createScript, readScript, deleteScript),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("customcrud.test_ws", "id"),
+					resource.TestCheckResourceAttr("customcrud.test_ws", "output.args.#", "1"),
+					resource.TestCheckResourceAttr("customcrud.test_ws", "output.args.0", "--label=hello world"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceWithSet(t *testing.T) {
 	createScript := "test_toset/create.sh"
 	readScript := "test_toset/read.sh"

--- a/internal/provider/test_whitespace_args/create.sh
+++ b/internal/provider/test_whitespace_args/create.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+input="$(cat)"
+id="$(echo "$input" | jq -r '.input.name')"
+
+# Build a JSON array from all positional arguments
+args_json=$(printf '%s\n' "$@" | jq --raw-input . | jq --slurp .)
+
+jq --null-input --arg id "$id" --argjson args "$args_json" '{id: $id, args: $args}'

--- a/internal/provider/test_whitespace_args/delete.sh
+++ b/internal/provider/test_whitespace_args/delete.sh
@@ -1,0 +1,1 @@
+../test_edgecases/delete.sh

--- a/internal/provider/test_whitespace_args/read.sh
+++ b/internal/provider/test_whitespace_args/read.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+input="$(cat)"
+id="$(echo "$input" | jq -r '.id')"
+
+# Build a JSON array from all positional arguments
+args_json=$(printf '%s\n' "$@" | jq --raw-input . | jq --slurp .)
+
+jq --null-input --arg id "$id" --argjson args "$args_json" '{id: $id, args: $args}'

--- a/internal/provider/utils/crud.go
+++ b/internal/provider/utils/crud.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/shell"
 )
 
 // CrudHooks is a generic struct for CRUD command strings
@@ -124,7 +123,11 @@ func RunCrudScript(ctx context.Context, config CustomCRUDProviderConfig, model C
 		diagnostics.AddError("Invalid Operation", fmt.Sprintf("Unknown operation: %v", op))
 		return nil, false
 	}
-	cmd := strings.Fields(commandStr)
+	cmd, err := shell.Fields(commandStr, nil)
+	if err != nil {
+		diagnostics.AddError(fmt.Sprintf("Invalid %v Command", op), fmt.Sprintf("failed to parse %v command: %v", op, err))
+		return nil, false
+	}
 	if len(cmd) == 0 {
 		diagnostics.AddError(fmt.Sprintf("Invalid %v Command", op), fmt.Sprintf("%v command cannot be empty", op))
 		return nil, false


### PR DESCRIPTION
## Related Issue

Fixes #60 

## Description

Splits command arguments taking quotes into consideration by using https://github.com/mvdan/sh. This also enables some fun new features in the hook strings:
> Fields performs shell expansion on s as if it were a command's arguments, using env to resolve variables. It is similar to Expand, but includes brace expansion, tilde expansion, and globbing.
(from https://pkg.go.dev/mvdan.cc/sh/v3/shell#pkg-examples)