### PR TITLE
feat(provider): add config option for default_inputs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,17 @@ provider "customcrud" {
   # This is useful if your scripts or tools are not safe to run concurrently.
   # This option defaults to 0 (unlimited parallelism).
   parallelism = 1
+
+  # `default_inputs` can be used for secret and non-secret config alike, and
+  # will be merged into the input field sent to the all hooks. They will not
+  # show up in any plans as they are only merged at execution time, this allows
+  # you to pass in secrets via this method, as they will not be stored in any
+  # plans or state, it will however still be visible in any debug logs if TF_LOG
+  # is enabled so proceed with caution.
+  default_inputs = {
+    api_url = var.api_url
+    api_key = var.api_key
+  }
 }
 ```
 
@@ -33,5 +44,6 @@ provider "customcrud" {
 
 ### Optional
 
+- `default_inputs` (Dynamic) Default input values merged into every resource and data source input. Resource-level input takes priority over these defaults.
 - `high_precision_numbers` (Boolean) Enable high precision for floating point numbers. This will cause the json parsing for outputs to use 512-bit floats instead of the default 64-bit.
 - `parallelism` (Number) Maximum number of scripts to execute in parallel. 0 means unlimited (default).

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -11,4 +11,15 @@ provider "customcrud" {
   # This is useful if your scripts or tools are not safe to run concurrently.
   # This option defaults to 0 (unlimited parallelism).
   parallelism = 1
+
+  # `default_inputs` can be used for secret and non-secret config alike, and
+  # will be merged into the input field sent to the all hooks. They will not
+  # show up in any plans as they are only merged at execution time, this allows
+  # you to pass in secrets via this method, as they will not be stored in any
+  # plans or state, it will however still be visible in any debug logs if TF_LOG
+  # is enabled so proceed with caution.
+  default_inputs = {
+    api_url = var.api_url
+    api_key = var.api_key
+  }
 }

--- a/internal/provider/custom_data_source.go
+++ b/internal/provider/custom_data_source.go
@@ -86,7 +86,7 @@ func (d *customCrudDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		}
 
 		payload := utils.ExecutionPayload{
-			Input: utils.AttrValueToInterface(data.Input.UnderlyingValue()),
+			Input: utils.MergeDefaultInputs(d.config, utils.AttrValueToInterface(data.Input.UnderlyingValue())),
 		}
 		result, ok := utils.RunCrudScript(ctx, d.config, &data, payload, &resp.Diagnostics, utils.CrudRead)
 		if !ok {

--- a/internal/provider/custom_resource.go
+++ b/internal/provider/custom_resource.go
@@ -217,7 +217,7 @@ func (r *customCrudResource) Create(ctx context.Context, req resource.CreateRequ
 
 		payload := utils.ExecutionPayload{
 			Id:     plan.Id.ValueString(),
-			Input:  r.mergeInputWithWO(plan.Input, config.InputWO),
+			Input:  utils.MergeDefaultInputs(r.config, r.mergeInputWithWO(plan.Input, config.InputWO)),
 			Output: utils.AttrValueToInterface(plan.Output.UnderlyingValue()),
 		}
 		result, ok := utils.RunCrudScript(ctx, r.config, plan, payload, &resp.Diagnostics, utils.CrudCreate)
@@ -253,7 +253,7 @@ func (r *customCrudResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 		payload := utils.ExecutionPayload{
 			Id:     state.Id.ValueString(),
-			Input:  utils.AttrValueToInterface(state.Input.UnderlyingValue()),
+			Input:  utils.MergeDefaultInputs(r.config, utils.AttrValueToInterface(state.Input.UnderlyingValue())),
 			Output: utils.AttrValueToInterface(state.Output.UnderlyingValue()),
 		}
 		result, ok := utils.RunCrudScript(ctx, r.config, state, payload, &resp.Diagnostics, utils.CrudRead)
@@ -289,7 +289,7 @@ func (r *customCrudResource) Update(ctx context.Context, req resource.UpdateRequ
 
 		payload := utils.ExecutionPayload{
 			Id:     plan.Id.ValueString(),
-			Input:  r.mergeInputWithWO(plan.Input, config.InputWO),
+			Input:  utils.MergeDefaultInputs(r.config, r.mergeInputWithWO(plan.Input, config.InputWO)),
 			Output: utils.AttrValueToInterface(state.Output.UnderlyingValue()),
 		}
 		// Only run crud script if input has changed, hook changes shouldn't trigger execution
@@ -328,7 +328,7 @@ func (r *customCrudResource) Delete(ctx context.Context, req resource.DeleteRequ
 		}
 		payload := utils.ExecutionPayload{
 			Id:     data.Id.ValueString(),
-			Input:  utils.AttrValueToInterface(data.Input.UnderlyingValue()),
+			Input:  utils.MergeDefaultInputs(r.config, utils.AttrValueToInterface(data.Input.UnderlyingValue())),
 			Output: utils.AttrValueToInterface(data.Output.UnderlyingValue()),
 		}
 		_, _ = utils.RunCrudScript(ctx, r.config, data, payload, &resp.Diagnostics, utils.CrudDelete)
@@ -413,7 +413,7 @@ func (r *customCrudResource) ImportState(ctx context.Context, req resource.Impor
 
 	payload := utils.ExecutionPayload{
 		Id:     importData.Id,
-		Input:  importData.Input,
+		Input:  utils.MergeDefaultInputs(r.config, importData.Input),
 		Output: importData.Output,
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,9 +31,9 @@ type CustomCRUDProvider struct {
 }
 
 type CustomCRUDProviderModel struct {
-	// Provider-level configuration can be added here if needed
-	Parallelism          types.Int64 `tfsdk:"parallelism"`
-	HighPrecisionNumbers types.Bool  `tfsdk:"high_precision_numbers"`
+	Parallelism          types.Int64   `tfsdk:"parallelism"`
+	HighPrecisionNumbers types.Bool    `tfsdk:"high_precision_numbers"`
+	DefaultInputs        types.Dynamic `tfsdk:"default_inputs"`
 }
 
 func (p *CustomCRUDProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -53,7 +53,10 @@ func (p *CustomCRUDProvider) Schema(ctx context.Context, req provider.SchemaRequ
 				Optional:            true,
 				MarkdownDescription: "Enable high precision for floating point numbers. This will cause the json parsing for outputs to use 512-bit floats instead of the default 64-bit.",
 			},
-			// Provider configuration attributes can be added here
+			"default_inputs": schema.DynamicAttribute{
+				Optional:            true,
+				MarkdownDescription: "Default input values merged into every resource and data source input. Resource-level input takes priority over these defaults.",
+			},
 		},
 	}
 }
@@ -78,6 +81,10 @@ func (p *CustomCRUDProvider) Configure(ctx context.Context, req provider.Configu
 
 	if !data.HighPrecisionNumbers.IsNull() {
 		p.config.HighPrecisionNumbers = data.HighPrecisionNumbers.ValueBool()
+	}
+
+	if !data.DefaultInputs.IsNull() && !data.DefaultInputs.IsUnknown() {
+		p.config.DefaultInputs = utils.AttrValueToInterface(data.DefaultInputs.UnderlyingValue())
 	}
 
 	resp.ResourceData = p

--- a/internal/provider/test_passthrough/create.sh
+++ b/internal/provider/test_passthrough/create.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Echoes input fields as output. If input contains remove_from_output (array of keys),
+# those keys (and remove_from_output itself) are removed from the output.
+input=$(cat)
+echo "$input" | jq '
+  {id: "test-passthrough"} + (.input // {})
+  | . as $base
+  | ($base.remove_from_output // []) as $keys
+  | $base | del(.remove_from_output)
+  | reduce ($keys[]) as $k (.; del(.[$k]))
+'

--- a/internal/provider/test_passthrough/delete.sh
+++ b/internal/provider/test_passthrough/delete.sh
@@ -1,0 +1,1 @@
+../test_edgecases/delete.sh

--- a/internal/provider/test_passthrough/read.sh
+++ b/internal/provider/test_passthrough/read.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Echoes input fields as output. If input contains remove_from_output (array of keys),
+# those keys (and remove_from_output itself) are removed from the output.
+input=$(cat)
+echo "$input" | jq '
+  {id: "test-passthrough"} + (.input // {})
+  | . as $base
+  | ($base.remove_from_output // []) as $keys
+  | $base | del(.remove_from_output)
+  | reduce ($keys[]) as $k (.; del(.[$k]))
+'

--- a/internal/provider/utils/crud.go
+++ b/internal/provider/utils/crud.go
@@ -91,6 +91,7 @@ type CustomCRUDProviderConfig struct {
 	Parallelism          int
 	HighPrecisionNumbers bool
 	Semaphore            chan struct{}
+	DefaultInputs        interface{}
 }
 
 func CustomCRUDProviderConfigDefaults() CustomCRUDProviderConfig {
@@ -98,6 +99,7 @@ func CustomCRUDProviderConfigDefaults() CustomCRUDProviderConfig {
 		Parallelism:          0,
 		HighPrecisionNumbers: false,
 		Semaphore:            nil,
+		DefaultInputs:        nil,
 	}
 }
 

--- a/internal/provider/utils/dynamic.go
+++ b/internal/provider/utils/dynamic.go
@@ -129,6 +129,29 @@ func InterfaceToAttrValueWithTypeHint(data interface{}, typeHint attr.Value) att
 	}
 }
 
+// MergeDefaultInputs merges provider-level default inputs with resource/data source input.
+// Resource input takes priority over default inputs.
+func MergeDefaultInputs(config CustomCRUDProviderConfig, input interface{}) interface{} {
+	if config.DefaultInputs == nil {
+		return input
+	}
+	merged := make(map[string]interface{})
+	if defaults, ok := config.DefaultInputs.(map[string]interface{}); ok {
+		for k, v := range defaults {
+			merged[k] = v
+		}
+	}
+	if inputMap, ok := input.(map[string]interface{}); ok {
+		for k, v := range inputMap {
+			merged[k] = v
+		}
+	}
+	if len(merged) == 0 {
+		return input
+	}
+	return merged
+}
+
 // AttrValueToInterface converts an attr.Value to a Go value.
 func AttrValueToInterface(val attr.Value) interface{} {
 	switch v := val.(type) {


### PR DESCRIPTION
## Related Issue

Fixes #61 

## Description

This allows you to set `default_inputs` on the provider, these can be used for secret and non-secret config alike, and will be merged into the input field sent to the hook. They will not show up in any plans as they are only merged at execution time, this allows you to pass in secrets via this method, as they will not be stored in any plans or state, it will however still be visible in any debug logs if TF_LOG is enabled so proceed with caution.