### PR TITLE
feat(provider): make exit code for missing resources configurable at provider level

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,4 +46,5 @@ provider "customcrud" {
 
 - `default_inputs` (Dynamic) Default input values merged into every resource and data source input. Resource-level input takes priority over these defaults.
 - `high_precision_numbers` (Boolean) Enable high precision for floating point numbers. This will cause the json parsing for outputs to use 512-bit floats instead of the default 64-bit.
+- `missing_resource_exit_code` (Number) Exit code that indicates a resource no longer exists on the remote. Defaults to 22.
 - `parallelism` (Number) Maximum number of scripts to execute in parallel. 0 means unlimited (default).

--- a/internal/provider/custom_resource.go
+++ b/internal/provider/custom_resource.go
@@ -258,8 +258,8 @@ func (r *customCrudResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 		result, ok := utils.RunCrudScript(ctx, r.config, state, payload, &resp.Diagnostics, utils.CrudRead)
 		if !ok {
-			// Special case: treat exit code 22 as resource removed
-			if result != nil && result.ExitCode == 22 {
+			// Special case: treat configured exit code as resource removed
+			if result != nil && result.ExitCode == r.config.MissingResourceExitCode {
 				resp.State.RemoveResource(ctx)
 			}
 			return

--- a/internal/provider/custom_resource_test.go
+++ b/internal/provider/custom_resource_test.go
@@ -249,6 +249,39 @@ func TestAccResourceRemovedRemote(t *testing.T) {
 	})
 }
 
+func TestAccResourceRemovedRemoteCustomExitCode(t *testing.T) {
+	createScript := "../../examples/file/hooks/create.sh"
+	readScript := "../../examples/file/hooks/read.sh"
+	deleteScript := "../../examples/file/hooks/delete.sh"
+	readScriptSimulateRemoval := "test_resource_removed_remote/read_simulate_removed_remote_custom_exit.sh"
+
+	content := "Test content for remote removal custom exit"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Simulate the resource being removed with custom exit code 42
+			{
+				Config: testAccResourceRemovedRemoteCustomExitCodeConfig(createScript, readScriptSimulateRemoval, deleteScript, content),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("customcrud.test", "output.content", content),
+					resource.TestCheckResourceAttrSet("customcrud.test", "id"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			// Then use normal read script to verify re-creation
+			{
+				Config: testAccResourceRemovedRemoteCustomExitCodeConfig(createScript, readScript, deleteScript, content),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("customcrud.test", "output.content", content),
+					resource.TestCheckResourceAttrSet("customcrud.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccParallelism_SerializesExecution(t *testing.T) {
 
 	dir, err := filepath.Abs("test_parallel")
@@ -423,6 +456,25 @@ resource "customcrud" "test" {
 
 func testAccResourceRemovedRemoteConfig(createScript, readScript, deleteScript, content string) string {
 	return fmt.Sprintf(`
+resource "customcrud" "test" {
+  hooks {
+    create = %[1]q
+    read   = %[2]q
+    delete = %[3]q
+  }
+  input = {
+    content = %[4]q
+  }
+}
+`, createScript, readScript, deleteScript, content)
+}
+
+func testAccResourceRemovedRemoteCustomExitCodeConfig(createScript, readScript, deleteScript, content string) string {
+	return fmt.Sprintf(`
+provider "customcrud" {
+  missing_resource_exit_code = 42
+}
+
 resource "customcrud" "test" {
   hooks {
     create = %[1]q

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,9 +31,10 @@ type CustomCRUDProvider struct {
 }
 
 type CustomCRUDProviderModel struct {
-	Parallelism          types.Int64   `tfsdk:"parallelism"`
-	HighPrecisionNumbers types.Bool    `tfsdk:"high_precision_numbers"`
-	DefaultInputs        types.Dynamic `tfsdk:"default_inputs"`
+	Parallelism             types.Int64   `tfsdk:"parallelism"`
+	HighPrecisionNumbers    types.Bool    `tfsdk:"high_precision_numbers"`
+	DefaultInputs           types.Dynamic `tfsdk:"default_inputs"`
+	MissingResourceExitCode types.Int64   `tfsdk:"missing_resource_exit_code"`
 }
 
 func (p *CustomCRUDProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -56,6 +57,10 @@ func (p *CustomCRUDProvider) Schema(ctx context.Context, req provider.SchemaRequ
 			"default_inputs": schema.DynamicAttribute{
 				Optional:            true,
 				MarkdownDescription: "Default input values merged into every resource and data source input. Resource-level input takes priority over these defaults.",
+			},
+			"missing_resource_exit_code": schema.Int64Attribute{
+				Optional:            true,
+				MarkdownDescription: "Exit code that indicates a resource no longer exists on the remote. Defaults to 22.",
 			},
 		},
 	}
@@ -85,6 +90,10 @@ func (p *CustomCRUDProvider) Configure(ctx context.Context, req provider.Configu
 
 	if !data.DefaultInputs.IsNull() && !data.DefaultInputs.IsUnknown() {
 		p.config.DefaultInputs = utils.AttrValueToInterface(data.DefaultInputs.UnderlyingValue())
+	}
+
+	if !data.MissingResourceExitCode.IsNull() && !data.MissingResourceExitCode.IsUnknown() {
+		p.config.MissingResourceExitCode = int(data.MissingResourceExitCode.ValueInt64())
 	}
 
 	resp.ResourceData = p

--- a/internal/provider/test_resource_removed_remote/read_simulate_removed_remote_custom_exit.sh
+++ b/internal/provider/test_resource_removed_remote/read_simulate_removed_remote_custom_exit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+exit 42

--- a/internal/provider/utils/crud.go
+++ b/internal/provider/utils/crud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -113,18 +114,20 @@ func (op CrudOp) String() string {
 }
 
 type CustomCRUDProviderConfig struct {
-	Parallelism          int
-	HighPrecisionNumbers bool
-	Semaphore            chan struct{}
-	DefaultInputs        interface{}
+	Parallelism             int
+	HighPrecisionNumbers    bool
+	Semaphore               chan struct{}
+	DefaultInputs           interface{}
+	MissingResourceExitCode int
 }
 
 func CustomCRUDProviderConfigDefaults() CustomCRUDProviderConfig {
 	return CustomCRUDProviderConfig{
-		Parallelism:          0,
-		HighPrecisionNumbers: false,
-		Semaphore:            nil,
-		DefaultInputs:        nil,
+		Parallelism:             0,
+		HighPrecisionNumbers:    false,
+		Semaphore:               nil,
+		DefaultInputs:           nil,
+		MissingResourceExitCode: 22,
 	}
 }
 
@@ -169,8 +172,8 @@ func RunCrudScript(ctx context.Context, config CustomCRUDProviderConfig, model C
 
 	title := cases.Title(language.English)
 	if err != nil {
-		// Special case: for Read operations with exit code 22, don't add error diagnostic
-		if op == CrudRead && result != nil && result.ExitCode == 22 {
+		// Special case: for Read operations with the configured missing resource exit code, don't add error diagnostic
+		if op == CrudRead && result != nil && result.ExitCode == config.MissingResourceExitCode {
 			return result, false
 		}
 		payloadJSON, _ := json.Marshal(payload)


### PR DESCRIPTION
This change makes the exit code which for missing resources configurable, this defaults to `22` to match the code curl gives for a 404, however, curl also returns `22` when there is any other 4XX response code, which could be problematic if your access token expires or similar.

This is now configurable through the provider config like so:

```hcl
provider "customcrud" {
  missing_resource_exit_code = 42
}
```