### PR TITLE
feat(provider): allow missing resource feature to be disabled

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,5 +46,5 @@ provider "customcrud" {
 
 - `default_inputs` (Dynamic) Default input values merged into every resource and data source input. Resource-level input takes priority over these defaults.
 - `high_precision_numbers` (Boolean) Enable high precision for floating point numbers. This will cause the json parsing for outputs to use 512-bit floats instead of the default 64-bit.
-- `missing_resource_exit_code` (Number) Exit code that indicates a resource no longer exists on the remote. Defaults to 22.
+- `missing_resource_exit_code` (Number) Exit code that indicates a resource no longer exists on the remote. Defaults to 22. Set to -1 to disable this feature.
 - `parallelism` (Number) Maximum number of scripts to execute in parallel. 0 means unlimited (default).

--- a/internal/provider/custom_resource.go
+++ b/internal/provider/custom_resource.go
@@ -259,7 +259,7 @@ func (r *customCrudResource) Read(ctx context.Context, req resource.ReadRequest,
 		result, ok := utils.RunCrudScript(ctx, r.config, state, payload, &resp.Diagnostics, utils.CrudRead)
 		if !ok {
 			// Special case: treat configured exit code as resource removed
-			if result != nil && result.ExitCode == r.config.MissingResourceExitCode {
+			if result != nil && r.config.MissingResourceExitCode != -1 && result.ExitCode == r.config.MissingResourceExitCode {
 				resp.State.RemoveResource(ctx)
 			}
 			return

--- a/internal/provider/custom_resource_test.go
+++ b/internal/provider/custom_resource_test.go
@@ -282,6 +282,26 @@ func TestAccResourceRemovedRemoteCustomExitCode(t *testing.T) {
 	})
 }
 
+func TestAccResourceRemovedRemoteDisabled(t *testing.T) {
+	createScript := "../../examples/file/hooks/create.sh"
+	deleteScript := "../../examples/file/hooks/delete.sh"
+	readScriptSimulateRemoval := "test_resource_removed_remote/read_simulate_removed_remote.sh"
+
+	content := "Test content for disabled missing resource exit code"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// With missing_resource_exit_code = -1, the default exit code 22 should not remove the resource
+			{
+				Config:      testAccResourceRemovedRemoteDisabledConfig(createScript, readScriptSimulateRemoval, deleteScript, content),
+				ExpectError: regexp.MustCompile(`Read Script Failed`),
+			},
+		},
+	})
+}
+
 func TestAccParallelism_SerializesExecution(t *testing.T) {
 
 	dir, err := filepath.Abs("test_parallel")
@@ -473,6 +493,25 @@ func testAccResourceRemovedRemoteCustomExitCodeConfig(createScript, readScript, 
 	return fmt.Sprintf(`
 provider "customcrud" {
   missing_resource_exit_code = 42
+}
+
+resource "customcrud" "test" {
+  hooks {
+    create = %[1]q
+    read   = %[2]q
+    delete = %[3]q
+  }
+  input = {
+    content = %[4]q
+  }
+}
+`, createScript, readScript, deleteScript, content)
+}
+
+func testAccResourceRemovedRemoteDisabledConfig(createScript, readScript, deleteScript, content string) string {
+	return fmt.Sprintf(`
+provider "customcrud" {
+  missing_resource_exit_code = -1
 }
 
 resource "customcrud" "test" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,7 +60,7 @@ func (p *CustomCRUDProvider) Schema(ctx context.Context, req provider.SchemaRequ
 			},
 			"missing_resource_exit_code": schema.Int64Attribute{
 				Optional:            true,
-				MarkdownDescription: "Exit code that indicates a resource no longer exists on the remote. Defaults to 22.",
+				MarkdownDescription: "Exit code that indicates a resource no longer exists on the remote. Defaults to 22. Set to -1 to disable this feature.",
 			},
 		},
 	}

--- a/internal/provider/utils/crud.go
+++ b/internal/provider/utils/crud.go
@@ -173,7 +173,7 @@ func RunCrudScript(ctx context.Context, config CustomCRUDProviderConfig, model C
 	title := cases.Title(language.English)
 	if err != nil {
 		// Special case: for Read operations with the configured missing resource exit code, don't add error diagnostic
-		if op == CrudRead && result != nil && result.ExitCode == config.MissingResourceExitCode {
+		if op == CrudRead && result != nil && config.MissingResourceExitCode != -1 && result.ExitCode == config.MissingResourceExitCode {
 			return result, false
 		}
 		payloadJSON, _ := json.Marshal(payload)


### PR DESCRIPTION
## Description

There are some situations where there may not be a use-case for auto detecting and correcting removed resources, in this case, rather than trying to assign an uncommon exit code, disabling this feature entirely is much safer.

You can now use this to disable the feature:

```terraform
provider "customcrud" {
  missing_resource_exit_code = -1
}
```
